### PR TITLE
add serial number prefix for instance array label

### DIFF
--- a/pkg/server/cmd_server.go
+++ b/pkg/server/cmd_server.go
@@ -1698,7 +1698,7 @@ func addServerToInfrastructure(serverID int, infrastructureIDOrLabel *string, ob
 
 	serverTypeID := server.ServerTypeID
 
-	instanceArrayLabel := server.ServerSerialNumber
+	instanceArrayLabel := "sn-" + server.ServerSerialNumber
 
 	if obj != nil && *obj.InstanceArrayLabel != "" {
 		instanceArrayLabel = *obj.InstanceArrayLabel


### PR DESCRIPTION
Some serial numbers don't comply with MetalSoft product label policy