### PR TITLE
network-device, point-to-point-link: add fabric-switch config primitives

### DIFF
--- a/cmd/metalcloud-cli/cmd/network_device.go
+++ b/cmd/metalcloud-cli/cmd/network_device.go
@@ -13,6 +13,11 @@ var (
 		configSource     string
 		portId           string
 		portStatusAction string
+		portEnabled      bool
+		portDescription  string
+		portIpFamily     string
+		portIpAddress    string
+		portIpPrefix     int32
 	}{}
 
 	networkDeviceCmd = &cobra.Command{
@@ -425,6 +430,81 @@ Examples:
 		},
 	}
 
+	networkDeviceUpdatePortConfigCmd = &cobra.Command{
+		Use:   "update-port-config <network_device_id>",
+		Short: "Update the staged config (enable/description) of a port",
+		Long: `Update the staged configuration of a single network device port, addressed
+by its numeric interface id.
+
+This patches the port's persistent config (applied on the next fabric deploy),
+not its live administrative status (use 'set-port-status' for that). You can set
+the enabled flag and/or the interface description.
+
+Arguments:
+  network_device_id   The unique identifier of the network device
+
+Required Flags:
+  --port-id           Numeric interface id of the port to configure
+
+Optional Flags (at least one must be specified):
+  --enabled           Whether the port should be enabled (true/false)
+  --description       Interface description text
+
+Examples:
+  # Enable a port and set its description
+  metalcloud-cli network-device update-port-config 12345 --port-id 67890 --enabled --description "to_spine-s00_swp1s0"
+
+  # Only set a description
+  metalcloud-cli nd update-port-config 12345 --port-id 67890 --description "to_hgx-su00-h00_enp26s0f0np0"`,
+		SilenceUsage: true,
+		Annotations:  map[string]string{system.REQUIRED_PERMISSION: system.PERMISSION_SWITCHES_WRITE},
+		Args:         cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var enabled *bool
+			if cmd.Flags().Changed("enabled") {
+				enabled = &networkDeviceFlags.portEnabled
+			}
+			var description *string
+			if cmd.Flags().Changed("description") {
+				description = &networkDeviceFlags.portDescription
+			}
+
+			return network_device.NetworkDeviceUpdatePortConfig(cmd.Context(), args[0], networkDeviceFlags.portId, enabled, description)
+		},
+	}
+
+	networkDeviceAddPortIpCmd = &cobra.Command{
+		Use:   "add-port-ip <network_device_id>",
+		Short: "Add an IP address to a network device port",
+		Long: `Stage a new IP address on a network device port, addressed by its numeric
+interface id. Typically used to assign a /32 loopback address to the loopback
+interface.
+
+Arguments:
+  network_device_id   The unique identifier of the network device
+
+Required Flags:
+  --port-id           Numeric interface id of the port
+  --address           IP address to add (without prefix, e.g. "10.253.128.1")
+  --prefix            Prefix length (e.g. 32 for a loopback /32)
+
+Optional Flags:
+  --family            Address family: ipv4 (default) or ipv6
+
+Examples:
+  # Add a /32 loopback address
+  metalcloud-cli network-device add-port-ip 12345 --port-id 67890 --address 10.253.128.1 --prefix 32
+
+  # Add an IPv6 address
+  metalcloud-cli nd add-port-ip 12345 --port-id 67890 --family ipv6 --address 2001:db8::1 --prefix 128`,
+		SilenceUsage: true,
+		Annotations:  map[string]string{system.REQUIRED_PERMISSION: system.PERMISSION_SWITCHES_WRITE},
+		Args:         cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return network_device.NetworkDeviceAddPortIp(cmd.Context(), args[0], networkDeviceFlags.portId, networkDeviceFlags.portIpFamily, networkDeviceFlags.portIpAddress, networkDeviceFlags.portIpPrefix)
+		},
+	}
+
 	networkDeviceResetCmd = &cobra.Command{
 		Use:   "reset <network_device_id>",
 		Short: "Reset network device to factory defaults (destructive operation)",
@@ -632,6 +712,22 @@ func init() {
 	networkDeviceSetPortStatusCmd.Flags().StringVar(&networkDeviceFlags.portId, "port-id", "", "ID of the port to change status.")
 	networkDeviceSetPortStatusCmd.Flags().StringVar(&networkDeviceFlags.portStatusAction, "action", "", "Action to perform on the port (up/down).")
 	networkDeviceSetPortStatusCmd.MarkFlagsOneRequired("port-id", "action")
+
+	networkDeviceCmd.AddCommand(networkDeviceUpdatePortConfigCmd)
+	networkDeviceUpdatePortConfigCmd.Flags().StringVar(&networkDeviceFlags.portId, "port-id", "", "Numeric interface id of the port to configure.")
+	networkDeviceUpdatePortConfigCmd.Flags().BoolVar(&networkDeviceFlags.portEnabled, "enabled", false, "Whether the port should be enabled.")
+	networkDeviceUpdatePortConfigCmd.Flags().StringVar(&networkDeviceFlags.portDescription, "description", "", "Interface description text.")
+	networkDeviceUpdatePortConfigCmd.MarkFlagRequired("port-id")
+	networkDeviceUpdatePortConfigCmd.MarkFlagsOneRequired("enabled", "description")
+
+	networkDeviceCmd.AddCommand(networkDeviceAddPortIpCmd)
+	networkDeviceAddPortIpCmd.Flags().StringVar(&networkDeviceFlags.portId, "port-id", "", "Numeric interface id of the port.")
+	networkDeviceAddPortIpCmd.Flags().StringVar(&networkDeviceFlags.portIpFamily, "family", "ipv4", "Address family: ipv4 or ipv6.")
+	networkDeviceAddPortIpCmd.Flags().StringVar(&networkDeviceFlags.portIpAddress, "address", "", "IP address to add (without prefix).")
+	networkDeviceAddPortIpCmd.Flags().Int32Var(&networkDeviceFlags.portIpPrefix, "prefix", 0, "Prefix length (e.g. 32 for a loopback /32).")
+	networkDeviceAddPortIpCmd.MarkFlagRequired("port-id")
+	networkDeviceAddPortIpCmd.MarkFlagRequired("address")
+	networkDeviceAddPortIpCmd.MarkFlagRequired("prefix")
 
 	networkDeviceCmd.AddCommand(networkDeviceResetCmd)
 

--- a/cmd/metalcloud-cli/cmd/point_to_point_link.go
+++ b/cmd/metalcloud-cli/cmd/point_to_point_link.go
@@ -1,0 +1,177 @@
+package cmd
+
+import (
+	"github.com/metalsoft-io/metalcloud-cli/cmd/metalcloud-cli/system"
+	"github.com/metalsoft-io/metalcloud-cli/internal/point_to_point_link"
+	"github.com/metalsoft-io/metalcloud-cli/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+var (
+	pointToPointLinkFlags = struct {
+		configSource    string
+		interfaceId     string
+		routeDomainId   string
+		subnetId        int64
+		binding         string
+		scopeKind       string
+		scopeResourceId int64
+	}{}
+
+	pointToPointLinkCmd = &cobra.Command{
+		Use:     "point-to-point-link [command]",
+		Aliases: []string{"p2p-link", "p2p"},
+		Short:   "Manage point-to-point links between network interfaces",
+		Long: `Manage point-to-point links between network device (and server) interfaces.
+
+A point-to-point link connects two interfaces (or a single interface, for a
+half-connected link) and can carry IPv4/IPv6 subnet allocation strategies that
+assign the link's addresses. Links can be created fully staged (interfaces plus
+a manual /31 strategy) in one call via the create command's config source.`,
+	}
+
+	pointToPointLinkListCmd = &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List point-to-point links",
+		Long: `List point-to-point links, optionally filtered by a referenced interface id
+or route domain id.
+
+Examples:
+  metalcloud-cli point-to-point-link list
+  metalcloud-cli p2p ls --interface-id 1001
+  metalcloud-cli p2p ls --route-domain-id 5`,
+		SilenceUsage: true,
+		Annotations:  map[string]string{system.REQUIRED_PERMISSION: system.PERMISSION_NETWORK_FABRICS_READ},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return point_to_point_link.PointToPointLinkList(cmd.Context(), pointToPointLinkFlags.interfaceId, pointToPointLinkFlags.routeDomainId)
+		},
+	}
+
+	pointToPointLinkGetCmd = &cobra.Command{
+		Use:          "get link_id",
+		Aliases:      []string{"show"},
+		Short:        "Get details about a specific point-to-point link",
+		SilenceUsage: true,
+		Annotations:  map[string]string{system.REQUIRED_PERMISSION: system.PERMISSION_NETWORK_FABRICS_READ},
+		Args:         cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return point_to_point_link.PointToPointLinkGet(cmd.Context(), args[0])
+		},
+	}
+
+	pointToPointLinkConfigExampleCmd = &cobra.Command{
+		Use:          "config-example",
+		Short:        "Display a point-to-point link configuration example",
+		SilenceUsage: true,
+		Annotations:  map[string]string{system.REQUIRED_PERMISSION: system.PERMISSION_NETWORK_FABRICS_READ},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return point_to_point_link.PointToPointLinkConfigExample(cmd.Context())
+		},
+	}
+
+	pointToPointLinkCreateCmd = &cobra.Command{
+		Use:     "create",
+		Aliases: []string{"new"},
+		Short:   "Create a point-to-point link",
+		Long: `Create a point-to-point link from a JSON/YAML configuration.
+
+The configuration may include:
+- interfaceA / interfaceB: { type: "network_equipment_interface", interfaceId: <id> }
+  (omit interfaceB for a half-connected link)
+- description, mtu, routingActivation ("default" or "while_transporting_logical_network")
+- ipv4.subnetAllocationStrategies: one or more strategies staged on create
+  (e.g. a manual strategy with a subnetId and interfaceABinding)
+
+Required Flags:
+  --config-source    'pipe' to read from stdin, or a path to a JSON/YAML file.
+
+Examples:
+  metalcloud-cli point-to-point-link config-example > link.json
+  metalcloud-cli point-to-point-link create --config-source link.json
+  cat link.json | metalcloud-cli p2p create --config-source pipe`,
+		SilenceUsage: true,
+		Annotations:  map[string]string{system.REQUIRED_PERMISSION: system.PERMISSION_NETWORK_FABRICS_WRITE},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			config, err := utils.ReadConfigFromPipeOrFile(pointToPointLinkFlags.configSource)
+			if err != nil {
+				return err
+			}
+
+			return point_to_point_link.PointToPointLinkCreate(cmd.Context(), config)
+		},
+	}
+
+	pointToPointLinkAddIpv4StrategyCmd = &cobra.Command{
+		Use:   "add-ipv4-strategy link_id",
+		Short: "Attach a manual IPv4 subnet allocation strategy to a link",
+		Long: `Attach a manual IPv4 subnet allocation strategy to an existing point-to-point
+link. This is the repair path for a link that was created without its strategy;
+new links should stage the strategy on create instead.
+
+Arguments:
+  link_id            The ID of the point-to-point link
+
+Required Flags:
+  --subnet-id        ID of the IPAM subnet to allocate from
+  --binding          Which interface gets the first address: a_first, b_first, or auto
+
+Optional Flags:
+  --scope-kind       Allocation scope kind (default: global)
+  --scope-resource-id   Resource id for non-global scopes (default: 0)
+
+Examples:
+  metalcloud-cli p2p add-ipv4-strategy 42 --subnet-id 12345 --binding a_first
+  metalcloud-cli p2p add-ipv4-strategy 42 --subnet-id 12345 --binding b_first`,
+		SilenceUsage: true,
+		Annotations:  map[string]string{system.REQUIRED_PERMISSION: system.PERMISSION_NETWORK_FABRICS_WRITE},
+		Args:         cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return point_to_point_link.PointToPointLinkAddIpv4Strategy(
+				cmd.Context(),
+				args[0],
+				pointToPointLinkFlags.subnetId,
+				pointToPointLinkFlags.binding,
+				pointToPointLinkFlags.scopeKind,
+				pointToPointLinkFlags.scopeResourceId,
+			)
+		},
+	}
+
+	pointToPointLinkDeleteCmd = &cobra.Command{
+		Use:          "delete link_id",
+		Aliases:      []string{"rm"},
+		Short:        "Delete a point-to-point link",
+		SilenceUsage: true,
+		Annotations:  map[string]string{system.REQUIRED_PERMISSION: system.PERMISSION_NETWORK_FABRICS_WRITE},
+		Args:         cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return point_to_point_link.PointToPointLinkDelete(cmd.Context(), args[0])
+		},
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(pointToPointLinkCmd)
+
+	pointToPointLinkCmd.AddCommand(pointToPointLinkListCmd)
+	pointToPointLinkListCmd.Flags().StringVar(&pointToPointLinkFlags.interfaceId, "interface-id", "", "Filter links by a referenced interface id.")
+	pointToPointLinkListCmd.Flags().StringVar(&pointToPointLinkFlags.routeDomainId, "route-domain-id", "", "Filter links by route domain id.")
+
+	pointToPointLinkCmd.AddCommand(pointToPointLinkGetCmd)
+
+	pointToPointLinkCmd.AddCommand(pointToPointLinkConfigExampleCmd)
+
+	pointToPointLinkCmd.AddCommand(pointToPointLinkCreateCmd)
+	pointToPointLinkCreateCmd.Flags().StringVar(&pointToPointLinkFlags.configSource, "config-source", "", "Source of the new link configuration. Can be 'pipe' or path to a JSON/YAML file.")
+	pointToPointLinkCreateCmd.MarkFlagRequired("config-source")
+
+	pointToPointLinkCmd.AddCommand(pointToPointLinkAddIpv4StrategyCmd)
+	pointToPointLinkAddIpv4StrategyCmd.Flags().Int64Var(&pointToPointLinkFlags.subnetId, "subnet-id", 0, "ID of the IPAM subnet to allocate from.")
+	pointToPointLinkAddIpv4StrategyCmd.Flags().StringVar(&pointToPointLinkFlags.binding, "binding", "a_first", "Interface A binding: a_first, b_first, or auto.")
+	pointToPointLinkAddIpv4StrategyCmd.Flags().StringVar(&pointToPointLinkFlags.scopeKind, "scope-kind", "global", "Allocation scope kind.")
+	pointToPointLinkAddIpv4StrategyCmd.Flags().Int64Var(&pointToPointLinkFlags.scopeResourceId, "scope-resource-id", 0, "Resource id for non-global scopes.")
+	pointToPointLinkAddIpv4StrategyCmd.MarkFlagRequired("subnet-id")
+
+	pointToPointLinkCmd.AddCommand(pointToPointLinkDeleteCmd)
+}

--- a/docs/metalcloud-cli.md
+++ b/docs/metalcloud-cli.md
@@ -55,6 +55,7 @@ metalcloud-cli [flags]
 * [metalcloud-cli network-device](metalcloud-cli_network-device.md)	 - Manage network devices (switches) in the infrastructure
 * [metalcloud-cli os-template](metalcloud-cli_os-template.md)	 - Manage OS templates for server deployments
 * [metalcloud-cli permission](metalcloud-cli_permission.md)	 - Permission management
+* [metalcloud-cli point-to-point-link](metalcloud-cli_point-to-point-link.md)	 - Manage point-to-point links between network interfaces
 * [metalcloud-cli quota-profile](metalcloud-cli_quota-profile.md)	 - Quota Profile management
 * [metalcloud-cli resource-pool](metalcloud-cli_resource-pool.md)	 - Manage resource pools and their associated resources
 * [metalcloud-cli role](metalcloud-cli_role.md)	 - Manage user roles and permissions

--- a/docs/metalcloud-cli_network-device.md
+++ b/docs/metalcloud-cli_network-device.md
@@ -33,6 +33,7 @@ monitor network devices.
 
 * [metalcloud-cli](metalcloud-cli.md)	 - MetalCloud CLI
 * [metalcloud-cli network-device add-defaults](metalcloud-cli_network-device_add-defaults.md)	 - Add network device default configuration
+* [metalcloud-cli network-device add-port-ip](metalcloud-cli_network-device_add-port-ip.md)	 - Add an IP address to a network device port
 * [metalcloud-cli network-device archive](metalcloud-cli_network-device_archive.md)	 - Archive a network device (soft delete with history preservation)
 * [metalcloud-cli network-device config-example](metalcloud-cli_network-device_config-example.md)	 - Generate example configuration template for network devices
 * [metalcloud-cli network-device create](metalcloud-cli_network-device_create.md)	 - Create a new network device with specified configuration
@@ -52,4 +53,5 @@ monitor network devices.
 * [metalcloud-cli network-device set-failed](metalcloud-cli_network-device_set-failed.md)	 - Set the network device as failed
 * [metalcloud-cli network-device set-port-status](metalcloud-cli_network-device_set-port-status.md)	 - Enable or disable a specific port on the network device
 * [metalcloud-cli network-device update](metalcloud-cli_network-device_update.md)	 - Update configuration of an existing network device
+* [metalcloud-cli network-device update-port-config](metalcloud-cli_network-device_update-port-config.md)	 - Update the staged config (enable/description) of a port
 

--- a/docs/metalcloud-cli_network-device_add-port-ip.md
+++ b/docs/metalcloud-cli_network-device_add-port-ip.md
@@ -1,0 +1,59 @@
+## metalcloud-cli network-device add-port-ip
+
+Add an IP address to a network device port
+
+### Synopsis
+
+Stage a new IP address on a network device port, addressed by its numeric
+interface id. Typically used to assign a /32 loopback address to the loopback
+interface.
+
+Arguments:
+  network_device_id   The unique identifier of the network device
+
+Required Flags:
+  --port-id           Numeric interface id of the port
+  --address           IP address to add (without prefix, e.g. "10.253.128.1")
+  --prefix            Prefix length (e.g. 32 for a loopback /32)
+
+Optional Flags:
+  --family            Address family: ipv4 (default) or ipv6
+
+Examples:
+  # Add a /32 loopback address
+  metalcloud-cli network-device add-port-ip 12345 --port-id 67890 --address 10.253.128.1 --prefix 32
+
+  # Add an IPv6 address
+  metalcloud-cli nd add-port-ip 12345 --port-id 67890 --family ipv6 --address 2001:db8::1 --prefix 128
+
+```
+metalcloud-cli network-device add-port-ip <network_device_id> [flags]
+```
+
+### Options
+
+```
+      --address string   IP address to add (without prefix).
+      --family string    Address family: ipv4 or ipv6. (default "ipv4")
+  -h, --help             help for add-port-ip
+      --port-id string   Numeric interface id of the port.
+      --prefix int32     Prefix length (e.g. 32 for a loopback /32).
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --api_key string         MetalCloud API key
+  -c, --config string          Config file path
+  -d, --debug                  Set to enable debug logging
+  -e, --endpoint string        MetalCloud API endpoint
+  -f, --format string          Output format. Supported values are 'text','csv','md','json','yaml'. (default "text")
+  -i, --insecure_skip_verify   Set to allow insecure transport
+  -l, --log_file string        Log file path
+  -v, --verbosity string       Log level verbosity (default "INFO")
+```
+
+### SEE ALSO
+
+* [metalcloud-cli network-device](metalcloud-cli_network-device.md)	 - Manage network devices (switches) in the infrastructure
+

--- a/docs/metalcloud-cli_network-device_update-port-config.md
+++ b/docs/metalcloud-cli_network-device_update-port-config.md
@@ -1,0 +1,60 @@
+## metalcloud-cli network-device update-port-config
+
+Update the staged config (enable/description) of a port
+
+### Synopsis
+
+Update the staged configuration of a single network device port, addressed
+by its numeric interface id.
+
+This patches the port's persistent config (applied on the next fabric deploy),
+not its live administrative status (use 'set-port-status' for that). You can set
+the enabled flag and/or the interface description.
+
+Arguments:
+  network_device_id   The unique identifier of the network device
+
+Required Flags:
+  --port-id           Numeric interface id of the port to configure
+
+Optional Flags (at least one must be specified):
+  --enabled           Whether the port should be enabled (true/false)
+  --description       Interface description text
+
+Examples:
+  # Enable a port and set its description
+  metalcloud-cli network-device update-port-config 12345 --port-id 67890 --enabled --description "to_spine-s00_swp1s0"
+
+  # Only set a description
+  metalcloud-cli nd update-port-config 12345 --port-id 67890 --description "to_hgx-su00-h00_enp26s0f0np0"
+
+```
+metalcloud-cli network-device update-port-config <network_device_id> [flags]
+```
+
+### Options
+
+```
+      --description string   Interface description text.
+      --enabled              Whether the port should be enabled.
+  -h, --help                 help for update-port-config
+      --port-id string       Numeric interface id of the port to configure.
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --api_key string         MetalCloud API key
+  -c, --config string          Config file path
+  -d, --debug                  Set to enable debug logging
+  -e, --endpoint string        MetalCloud API endpoint
+  -f, --format string          Output format. Supported values are 'text','csv','md','json','yaml'. (default "text")
+  -i, --insecure_skip_verify   Set to allow insecure transport
+  -l, --log_file string        Log file path
+  -v, --verbosity string       Log level verbosity (default "INFO")
+```
+
+### SEE ALSO
+
+* [metalcloud-cli network-device](metalcloud-cli_network-device.md)	 - Manage network devices (switches) in the infrastructure
+

--- a/docs/metalcloud-cli_point-to-point-link.md
+++ b/docs/metalcloud-cli_point-to-point-link.md
@@ -1,0 +1,42 @@
+## metalcloud-cli point-to-point-link
+
+Manage point-to-point links between network interfaces
+
+### Synopsis
+
+Manage point-to-point links between network device (and server) interfaces.
+
+A point-to-point link connects two interfaces (or a single interface, for a
+half-connected link) and can carry IPv4/IPv6 subnet allocation strategies that
+assign the link's addresses. Links can be created fully staged (interfaces plus
+a manual /31 strategy) in one call via the create command's config source.
+
+### Options
+
+```
+  -h, --help   help for point-to-point-link
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --api_key string         MetalCloud API key
+  -c, --config string          Config file path
+  -d, --debug                  Set to enable debug logging
+  -e, --endpoint string        MetalCloud API endpoint
+  -f, --format string          Output format. Supported values are 'text','csv','md','json','yaml'. (default "text")
+  -i, --insecure_skip_verify   Set to allow insecure transport
+  -l, --log_file string        Log file path
+  -v, --verbosity string       Log level verbosity (default "INFO")
+```
+
+### SEE ALSO
+
+* [metalcloud-cli](metalcloud-cli.md)	 - MetalCloud CLI
+* [metalcloud-cli point-to-point-link add-ipv4-strategy](metalcloud-cli_point-to-point-link_add-ipv4-strategy.md)	 - Attach a manual IPv4 subnet allocation strategy to a link
+* [metalcloud-cli point-to-point-link config-example](metalcloud-cli_point-to-point-link_config-example.md)	 - Display a point-to-point link configuration example
+* [metalcloud-cli point-to-point-link create](metalcloud-cli_point-to-point-link_create.md)	 - Create a point-to-point link
+* [metalcloud-cli point-to-point-link delete](metalcloud-cli_point-to-point-link_delete.md)	 - Delete a point-to-point link
+* [metalcloud-cli point-to-point-link get](metalcloud-cli_point-to-point-link_get.md)	 - Get details about a specific point-to-point link
+* [metalcloud-cli point-to-point-link list](metalcloud-cli_point-to-point-link_list.md)	 - List point-to-point links
+

--- a/docs/metalcloud-cli_point-to-point-link_add-ipv4-strategy.md
+++ b/docs/metalcloud-cli_point-to-point-link_add-ipv4-strategy.md
@@ -1,0 +1,56 @@
+## metalcloud-cli point-to-point-link add-ipv4-strategy
+
+Attach a manual IPv4 subnet allocation strategy to a link
+
+### Synopsis
+
+Attach a manual IPv4 subnet allocation strategy to an existing point-to-point
+link. This is the repair path for a link that was created without its strategy;
+new links should stage the strategy on create instead.
+
+Arguments:
+  link_id            The ID of the point-to-point link
+
+Required Flags:
+  --subnet-id        ID of the IPAM subnet to allocate from
+  --binding          Which interface gets the first address: a_first, b_first, or auto
+
+Optional Flags:
+  --scope-kind       Allocation scope kind (default: global)
+  --scope-resource-id   Resource id for non-global scopes (default: 0)
+
+Examples:
+  metalcloud-cli p2p add-ipv4-strategy 42 --subnet-id 12345 --binding a_first
+  metalcloud-cli p2p add-ipv4-strategy 42 --subnet-id 12345 --binding b_first
+
+```
+metalcloud-cli point-to-point-link add-ipv4-strategy link_id [flags]
+```
+
+### Options
+
+```
+      --binding string          Interface A binding: a_first, b_first, or auto. (default "a_first")
+  -h, --help                    help for add-ipv4-strategy
+      --scope-kind string       Allocation scope kind. (default "global")
+      --scope-resource-id int   Resource id for non-global scopes.
+      --subnet-id int           ID of the IPAM subnet to allocate from.
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --api_key string         MetalCloud API key
+  -c, --config string          Config file path
+  -d, --debug                  Set to enable debug logging
+  -e, --endpoint string        MetalCloud API endpoint
+  -f, --format string          Output format. Supported values are 'text','csv','md','json','yaml'. (default "text")
+  -i, --insecure_skip_verify   Set to allow insecure transport
+  -l, --log_file string        Log file path
+  -v, --verbosity string       Log level verbosity (default "INFO")
+```
+
+### SEE ALSO
+
+* [metalcloud-cli point-to-point-link](metalcloud-cli_point-to-point-link.md)	 - Manage point-to-point links between network interfaces
+

--- a/docs/metalcloud-cli_point-to-point-link_config-example.md
+++ b/docs/metalcloud-cli_point-to-point-link_config-example.md
@@ -1,0 +1,31 @@
+## metalcloud-cli point-to-point-link config-example
+
+Display a point-to-point link configuration example
+
+```
+metalcloud-cli point-to-point-link config-example [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for config-example
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --api_key string         MetalCloud API key
+  -c, --config string          Config file path
+  -d, --debug                  Set to enable debug logging
+  -e, --endpoint string        MetalCloud API endpoint
+  -f, --format string          Output format. Supported values are 'text','csv','md','json','yaml'. (default "text")
+  -i, --insecure_skip_verify   Set to allow insecure transport
+  -l, --log_file string        Log file path
+  -v, --verbosity string       Log level verbosity (default "INFO")
+```
+
+### SEE ALSO
+
+* [metalcloud-cli point-to-point-link](metalcloud-cli_point-to-point-link.md)	 - Manage point-to-point links between network interfaces
+

--- a/docs/metalcloud-cli_point-to-point-link_create.md
+++ b/docs/metalcloud-cli_point-to-point-link_create.md
@@ -1,0 +1,51 @@
+## metalcloud-cli point-to-point-link create
+
+Create a point-to-point link
+
+### Synopsis
+
+Create a point-to-point link from a JSON/YAML configuration.
+
+The configuration may include:
+- interfaceA / interfaceB: { type: "network_equipment_interface", interfaceId: <id> }
+  (omit interfaceB for a half-connected link)
+- description, mtu, routingActivation ("default" or "while_transporting_logical_network")
+- ipv4.subnetAllocationStrategies: one or more strategies staged on create
+  (e.g. a manual strategy with a subnetId and interfaceABinding)
+
+Required Flags:
+  --config-source    'pipe' to read from stdin, or a path to a JSON/YAML file.
+
+Examples:
+  metalcloud-cli point-to-point-link config-example > link.json
+  metalcloud-cli point-to-point-link create --config-source link.json
+  cat link.json | metalcloud-cli p2p create --config-source pipe
+
+```
+metalcloud-cli point-to-point-link create [flags]
+```
+
+### Options
+
+```
+      --config-source string   Source of the new link configuration. Can be 'pipe' or path to a JSON/YAML file.
+  -h, --help                   help for create
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --api_key string         MetalCloud API key
+  -c, --config string          Config file path
+  -d, --debug                  Set to enable debug logging
+  -e, --endpoint string        MetalCloud API endpoint
+  -f, --format string          Output format. Supported values are 'text','csv','md','json','yaml'. (default "text")
+  -i, --insecure_skip_verify   Set to allow insecure transport
+  -l, --log_file string        Log file path
+  -v, --verbosity string       Log level verbosity (default "INFO")
+```
+
+### SEE ALSO
+
+* [metalcloud-cli point-to-point-link](metalcloud-cli_point-to-point-link.md)	 - Manage point-to-point links between network interfaces
+

--- a/docs/metalcloud-cli_point-to-point-link_delete.md
+++ b/docs/metalcloud-cli_point-to-point-link_delete.md
@@ -1,0 +1,31 @@
+## metalcloud-cli point-to-point-link delete
+
+Delete a point-to-point link
+
+```
+metalcloud-cli point-to-point-link delete link_id [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --api_key string         MetalCloud API key
+  -c, --config string          Config file path
+  -d, --debug                  Set to enable debug logging
+  -e, --endpoint string        MetalCloud API endpoint
+  -f, --format string          Output format. Supported values are 'text','csv','md','json','yaml'. (default "text")
+  -i, --insecure_skip_verify   Set to allow insecure transport
+  -l, --log_file string        Log file path
+  -v, --verbosity string       Log level verbosity (default "INFO")
+```
+
+### SEE ALSO
+
+* [metalcloud-cli point-to-point-link](metalcloud-cli_point-to-point-link.md)	 - Manage point-to-point links between network interfaces
+

--- a/docs/metalcloud-cli_point-to-point-link_get.md
+++ b/docs/metalcloud-cli_point-to-point-link_get.md
@@ -1,0 +1,31 @@
+## metalcloud-cli point-to-point-link get
+
+Get details about a specific point-to-point link
+
+```
+metalcloud-cli point-to-point-link get link_id [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --api_key string         MetalCloud API key
+  -c, --config string          Config file path
+  -d, --debug                  Set to enable debug logging
+  -e, --endpoint string        MetalCloud API endpoint
+  -f, --format string          Output format. Supported values are 'text','csv','md','json','yaml'. (default "text")
+  -i, --insecure_skip_verify   Set to allow insecure transport
+  -l, --log_file string        Log file path
+  -v, --verbosity string       Log level verbosity (default "INFO")
+```
+
+### SEE ALSO
+
+* [metalcloud-cli point-to-point-link](metalcloud-cli_point-to-point-link.md)	 - Manage point-to-point links between network interfaces
+

--- a/docs/metalcloud-cli_point-to-point-link_list.md
+++ b/docs/metalcloud-cli_point-to-point-link_list.md
@@ -1,0 +1,43 @@
+## metalcloud-cli point-to-point-link list
+
+List point-to-point links
+
+### Synopsis
+
+List point-to-point links, optionally filtered by a referenced interface id
+or route domain id.
+
+Examples:
+  metalcloud-cli point-to-point-link list
+  metalcloud-cli p2p ls --interface-id 1001
+  metalcloud-cli p2p ls --route-domain-id 5
+
+```
+metalcloud-cli point-to-point-link list [flags]
+```
+
+### Options
+
+```
+  -h, --help                     help for list
+      --interface-id string      Filter links by a referenced interface id.
+      --route-domain-id string   Filter links by route domain id.
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --api_key string         MetalCloud API key
+  -c, --config string          Config file path
+  -d, --debug                  Set to enable debug logging
+  -e, --endpoint string        MetalCloud API endpoint
+  -f, --format string          Output format. Supported values are 'text','csv','md','json','yaml'. (default "text")
+  -i, --insecure_skip_verify   Set to allow insecure transport
+  -l, --log_file string        Log file path
+  -v, --verbosity string       Log level verbosity (default "INFO")
+```
+
+### SEE ALSO
+
+* [metalcloud-cli point-to-point-link](metalcloud-cli_point-to-point-link.md)	 - Manage point-to-point links between network interfaces
+

--- a/internal/network_device/network_device.go
+++ b/internal/network_device/network_device.go
@@ -3,9 +3,11 @@ package network_device
 import (
 	"context"
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -412,6 +414,189 @@ func NetworkDeviceSetPortStatus(ctx context.Context, networkDeviceId string, por
 
 	logger.Get().Info().Msgf("Port %s status for network device %s set to %s", portId, networkDeviceId, action)
 	return nil
+}
+
+var networkDevicePortConfigPrintConfig = formatter.PrintConfig{
+	FieldsConfig: map[string]formatter.RecordFieldConfig{
+		"Enabled": {
+			Title: "Enabled",
+			Order: 1,
+		},
+		"Description": {
+			Title: "Description",
+			Order: 2,
+		},
+		"Mtu": {
+			Title: "MTU",
+			Order: 3,
+		},
+		"Revision": {
+			Title: "Revision",
+			Order: 4,
+		},
+	},
+}
+
+var networkDevicePortIpPrintConfig = formatter.PrintConfig{
+	FieldsConfig: map[string]formatter.RecordFieldConfig{
+		"Id": {
+			Title: "#",
+			Order: 1,
+		},
+		"InterfaceId": {
+			Title: "Interface",
+			Order: 2,
+		},
+		"Address": {
+			Title: "Address",
+			Order: 3,
+		},
+		"PrefixLength": {
+			Title: "Prefix",
+			Order: 4,
+		},
+		"ServiceStatus": {
+			Title: "Status",
+			Order: 5,
+		},
+	},
+}
+
+// revisionMismatchRe extracts the server-expected revision out of an optimistic
+// locking 409 body ("... found 7 ..."), used to retry the staged port-IP POST.
+var revisionMismatchRe = regexp.MustCompile(`found (\d+)`)
+
+// NetworkDeviceUpdatePortConfig patches the staged config (enabled flag and/or
+// description) of a single network device port. The port is addressed by its
+// numeric interface id. The current config revision is read first and sent as
+// If-Match for optimistic concurrency.
+func NetworkDeviceUpdatePortConfig(ctx context.Context, networkDeviceId string, portId string, enabled *bool, description *string) error {
+	logger.Get().Info().Msgf("Updating port %s config of network device %s", portId, networkDeviceId)
+
+	networkDeviceIdNumeric, err := GetNetworkDeviceId(networkDeviceId)
+	if err != nil {
+		return err
+	}
+
+	portIdNumeric, err := getNetworkDevicePortId(portId)
+	if err != nil {
+		return err
+	}
+
+	if enabled == nil && description == nil {
+		return fmt.Errorf("nothing to update: specify --enabled and/or --description")
+	}
+
+	client := api.GetApiClient(ctx)
+
+	port, httpRes, err := client.NetworkDeviceAPI.
+		GetNetworkDevicePort(ctx, networkDeviceIdNumeric, portIdNumeric).
+		Execute()
+	if err := response_inspector.InspectResponse(httpRes, err); err != nil {
+		return err
+	}
+
+	configUpdate := sdk.UpdateNetworkEquipmentInterfaceConfig{}
+	if enabled != nil {
+		configUpdate.Enabled = *sdk.NewNullableBool(enabled)
+	}
+	if description != nil {
+		configUpdate.Description = *sdk.NewNullableString(description)
+	}
+
+	revision := strconv.FormatInt(port.Config.Revision, 10)
+
+	configInfo, httpRes, err := client.NetworkDeviceAPI.
+		UpdateNetworkDevicePortConfig(ctx, networkDeviceIdNumeric, portIdNumeric).
+		UpdateNetworkEquipmentInterfaceConfig(configUpdate).
+		IfMatch(revision).
+		Execute()
+	if err := response_inspector.InspectResponse(httpRes, err); err != nil {
+		return err
+	}
+
+	return formatter.PrintResult(configInfo, &networkDevicePortConfigPrintConfig)
+}
+
+// NetworkDeviceAddPortIp stages a new IP address on a network device port
+// (addressed by its numeric interface id), e.g. a /32 loopback address.
+//
+// The POST is guarded by optimistic locking, but the interface entity revision
+// is not served directly: the single-port GET exposes a zero-based
+// config.revision while the lock checks a one-based counter. We therefore send
+// config.revision + 1, and if the server still rejects with a 409 naming a
+// different current revision, retry once with the value it expects.
+func NetworkDeviceAddPortIp(ctx context.Context, networkDeviceId string, portId string, family string, address string, prefixLength int32) error {
+	logger.Get().Info().Msgf("Adding %s/%d to port %s of network device %s", address, prefixLength, portId, networkDeviceId)
+
+	networkDeviceIdNumeric, err := GetNetworkDeviceId(networkDeviceId)
+	if err != nil {
+		return err
+	}
+
+	portIdNumeric, err := getNetworkDevicePortId(portId)
+	if err != nil {
+		return err
+	}
+
+	client := api.GetApiClient(ctx)
+
+	port, httpRes, err := client.NetworkDeviceAPI.
+		GetNetworkDevicePort(ctx, networkDeviceIdNumeric, portIdNumeric).
+		Execute()
+	if err := response_inspector.InspectResponse(httpRes, err); err != nil {
+		return err
+	}
+
+	payload := sdk.AddNetworkEquipmentInterfaceIp{
+		Address:      address,
+		PrefixLength: prefixLength,
+	}
+
+	revision := strconv.FormatInt(port.Config.Revision+1, 10)
+
+	ipInfo, httpRes, err := client.NetworkDeviceAPI.
+		AddNetworkDevicePortIp(ctx, networkDeviceIdNumeric, portIdNumeric, family).
+		AddNetworkEquipmentInterfaceIp(payload).
+		IfMatch(revision).
+		Execute()
+
+	// Optimistic-lock retry: the server reports the revision it actually expects.
+	if err != nil && httpRes != nil && httpRes.StatusCode == 409 {
+		if expected := expectedRevisionFromError(err); expected != "" {
+			ipInfo, httpRes, err = client.NetworkDeviceAPI.
+				AddNetworkDevicePortIp(ctx, networkDeviceIdNumeric, portIdNumeric, family).
+				AddNetworkEquipmentInterfaceIp(payload).
+				IfMatch(expected).
+				Execute()
+		}
+	}
+	if err := response_inspector.InspectResponse(httpRes, err); err != nil {
+		return err
+	}
+
+	return formatter.PrintResult(ipInfo, &networkDevicePortIpPrintConfig)
+}
+
+func getNetworkDevicePortId(portId string) (int64, error) {
+	portIdNumeric, err := strconv.ParseInt(portId, 10, 64)
+	if err != nil {
+		err := fmt.Errorf("invalid port (interface) ID: '%s'", portId)
+		logger.Get().Error().Err(err).Msg("")
+		return 0, err
+	}
+
+	return portIdNumeric, nil
+}
+
+func expectedRevisionFromError(err error) string {
+	var apiErr sdk.GenericOpenAPIError
+	if errors.As(err, &apiErr) {
+		if m := revisionMismatchRe.FindSubmatch(apiErr.Body()); m != nil {
+			return string(m[1])
+		}
+	}
+	return ""
 }
 
 func NetworkDeviceReset(ctx context.Context, networkDeviceId string) error {

--- a/internal/point_to_point_link/point_to_point_link.go
+++ b/internal/point_to_point_link/point_to_point_link.go
@@ -1,0 +1,242 @@
+package point_to_point_link
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/metalsoft-io/metalcloud-cli/pkg/api"
+	"github.com/metalsoft-io/metalcloud-cli/pkg/formatter"
+	"github.com/metalsoft-io/metalcloud-cli/pkg/logger"
+	"github.com/metalsoft-io/metalcloud-cli/pkg/response_inspector"
+	"github.com/metalsoft-io/metalcloud-cli/pkg/utils"
+	sdk "github.com/metalsoft-io/metalcloud-sdk-go"
+)
+
+var PointToPointLinkPrintConfig = formatter.PrintConfig{
+	FieldsConfig: map[string]formatter.RecordFieldConfig{
+		"Id": {
+			Title: "#",
+			Order: 1,
+		},
+		"Label": {
+			Title: "Label",
+			Order: 2,
+		},
+		"Description": {
+			Title: "Description",
+			Order: 3,
+		},
+		"RoutingActivation": {
+			Title: "Routing Activation",
+			Order: 4,
+		},
+		"ServiceStatus": {
+			Title: "Status",
+			Order: 5,
+		},
+		"Revision": {
+			Title: "Revision",
+			Order: 6,
+		},
+	},
+}
+
+// PointToPointLinkList lists point-to-point links, optionally filtered by a
+// referenced interface id or route domain id.
+func PointToPointLinkList(ctx context.Context, interfaceId string, routeDomainId string) error {
+	logger.Get().Info().Msgf("Listing point-to-point links")
+
+	client := api.GetApiClient(ctx)
+
+	request := client.PointToPointLinkAPI.GetPointToPointLinks(ctx)
+	if interfaceId != "" {
+		request = request.InterfaceId(interfaceId)
+	}
+	if routeDomainId != "" {
+		request = request.RouteDomainId(routeDomainId)
+	}
+
+	links, httpRes, err := request.Execute()
+	if err := response_inspector.InspectResponse(httpRes, err); err != nil {
+		return err
+	}
+
+	return formatter.PrintResult(links, &PointToPointLinkPrintConfig)
+}
+
+// PointToPointLinkGet shows a single point-to-point link.
+func PointToPointLinkGet(ctx context.Context, linkId string) error {
+	logger.Get().Info().Msgf("Get point-to-point link %s details", linkId)
+
+	linkIdNumeric, err := getPointToPointLinkId(linkId)
+	if err != nil {
+		return err
+	}
+
+	client := api.GetApiClient(ctx)
+
+	link, httpRes, err := client.PointToPointLinkAPI.GetPointToPointLink(ctx, linkIdNumeric).Execute()
+	if err := response_inspector.InspectResponse(httpRes, err); err != nil {
+		return err
+	}
+
+	return formatter.PrintResult(link, &PointToPointLinkPrintConfig)
+}
+
+// PointToPointLinkCreate creates a point-to-point link from a raw configuration
+// body. The body may stage one or more IPv4/IPv6 subnet allocation strategies
+// inline (ipv4.subnetAllocationStrategies), so a fully-connected link plus its
+// manual /31 strategy can be created in a single call.
+func PointToPointLinkCreate(ctx context.Context, config []byte) error {
+	logger.Get().Info().Msgf("Creating point-to-point link")
+
+	var linkConfig sdk.CreatePointToPointLink
+	if err := utils.UnmarshalContent(config, &linkConfig); err != nil {
+		return err
+	}
+
+	client := api.GetApiClient(ctx)
+
+	link, httpRes, err := client.PointToPointLinkAPI.
+		CreatePointToPointLink(ctx).
+		CreatePointToPointLink(linkConfig).
+		Execute()
+	if err := response_inspector.InspectResponse(httpRes, err); err != nil {
+		return err
+	}
+
+	return formatter.PrintResult(link, &PointToPointLinkPrintConfig)
+}
+
+// PointToPointLinkDelete deletes a point-to-point link.
+func PointToPointLinkDelete(ctx context.Context, linkId string) error {
+	logger.Get().Info().Msgf("Deleting point-to-point link %s", linkId)
+
+	linkIdNumeric, revision, err := getPointToPointLinkIdAndRevision(ctx, linkId)
+	if err != nil {
+		return err
+	}
+
+	client := api.GetApiClient(ctx)
+
+	httpRes, err := client.PointToPointLinkAPI.
+		DeletePointToPointLink(ctx, linkIdNumeric).
+		IfMatch(revision).
+		Execute()
+	if err := response_inspector.InspectResponse(httpRes, err); err != nil {
+		return err
+	}
+
+	logger.Get().Info().Msgf("Point-to-point link %s deleted", linkId)
+	return nil
+}
+
+// PointToPointLinkAddIpv4Strategy attaches a manual IPv4 subnet allocation
+// strategy to an existing link. The link's current revision is sent as If-Match.
+func PointToPointLinkAddIpv4Strategy(ctx context.Context, linkId string, subnetId int64, binding string, scopeKind string, scopeResourceId int64) error {
+	logger.Get().Info().Msgf("Adding manual IPv4 allocation strategy (subnet %d) to point-to-point link %s", subnetId, linkId)
+
+	linkIdNumeric, revision, err := getPointToPointLinkIdAndRevision(ctx, linkId)
+	if err != nil {
+		return err
+	}
+
+	bindingValue, err := sdk.NewPointToPointInterfaceBindingFromValue(binding)
+	if err != nil {
+		return fmt.Errorf("invalid interface binding '%s': %w", binding, err)
+	}
+
+	scopeKindValue, err := sdk.NewResourceScopeKindFromValue(scopeKind)
+	if err != nil {
+		return fmt.Errorf("invalid scope kind '%s': %w", scopeKind, err)
+	}
+
+	manual := sdk.CreateManualIpv4PointToPointAllocationStrategy{
+		Kind: sdk.POINTTOPOINTALLOCATIONSTRATEGYKIND_MANUAL,
+		Scope: sdk.CreateResourceScope{
+			Kind:       *scopeKindValue,
+			ResourceId: scopeResourceId,
+		},
+		SubnetId:          subnetId,
+		InterfaceABinding: bindingValue,
+	}
+
+	strategyRequest := sdk.CreatePointToPointLinkConfigIpv4SubnetAllocationStrategyRequest{
+		CreateManualIpv4PointToPointAllocationStrategy: &manual,
+	}
+
+	client := api.GetApiClient(ctx)
+
+	result, httpRes, err := client.PointToPointLinkAPI.
+		CreatePointToPointLinkConfigIpv4SubnetAllocationStrategy(ctx, linkIdNumeric).
+		CreatePointToPointLinkConfigIpv4SubnetAllocationStrategyRequest(strategyRequest).
+		IfMatch(revision).
+		Execute()
+	if err := response_inspector.InspectResponse(httpRes, err); err != nil {
+		return err
+	}
+
+	return formatter.PrintResult(result, nil)
+}
+
+// PointToPointLinkConfigExample prints an example create body, including a staged
+// manual IPv4 /31 allocation strategy on interface A.
+func PointToPointLinkConfigExample(ctx context.Context) error {
+	example := sdk.CreatePointToPointLink{
+		Description:       sdk.PtrString("leaf-swp33s0 to spine-swp1s0"),
+		RoutingActivation: sdk.POINTTOPOINTLINKROUTINGACTIVATION_DEFAULT.Ptr(),
+		Mtu:               *sdk.NewNullableInt32(sdk.PtrInt32(9216)),
+		InterfaceA: *sdk.NewNullableCreatePointToPointInterface(&sdk.CreatePointToPointInterface{
+			Type:        sdk.POINTTOPOINTINTERFACETYPE_NETWORK_EQUIPMENT_INTERFACE,
+			InterfaceId: 1001,
+		}),
+		InterfaceB: *sdk.NewNullableCreatePointToPointInterface(&sdk.CreatePointToPointInterface{
+			Type:        sdk.POINTTOPOINTINTERFACETYPE_NETWORK_EQUIPMENT_INTERFACE,
+			InterfaceId: 2002,
+		}),
+		Ipv4: &sdk.CreatePointToPointLinkIpv4Properties{
+			SubnetAllocationStrategies: []sdk.CreatePointToPointLinkConfigIpv4SubnetAllocationStrategyRequest{
+				{
+					CreateManualIpv4PointToPointAllocationStrategy: &sdk.CreateManualIpv4PointToPointAllocationStrategy{
+						Kind: sdk.POINTTOPOINTALLOCATIONSTRATEGYKIND_MANUAL,
+						Scope: sdk.CreateResourceScope{
+							Kind: sdk.RESOURCESCOPEKIND_GLOBAL,
+						},
+						SubnetId:          12345,
+						InterfaceABinding: sdk.POINTTOPOINTINTERFACEBINDING_A_FIRST.Ptr(),
+					},
+				},
+			},
+		},
+	}
+
+	return formatter.PrintResult(example, nil)
+}
+
+func getPointToPointLinkId(linkId string) (float32, error) {
+	linkIdNumeric, err := strconv.ParseInt(linkId, 10, 64)
+	if err != nil {
+		err := fmt.Errorf("invalid point-to-point link ID: '%s'", linkId)
+		logger.Get().Error().Err(err).Msg("")
+		return 0, err
+	}
+
+	return float32(linkIdNumeric), nil
+}
+
+func getPointToPointLinkIdAndRevision(ctx context.Context, linkId string) (float32, string, error) {
+	linkIdNumeric, err := getPointToPointLinkId(linkId)
+	if err != nil {
+		return 0, "", err
+	}
+
+	client := api.GetApiClient(ctx)
+
+	link, httpRes, err := client.PointToPointLinkAPI.GetPointToPointLink(ctx, linkIdNumeric).Execute()
+	if err := response_inspector.InspectResponse(httpRes, err); err != nil {
+		return 0, "", err
+	}
+
+	return linkIdNumeric, strconv.FormatInt(link.Revision, 10), nil
+}


### PR DESCRIPTION
Additional network fabric configuration commands.

network-device:
- update-port-config: patch a port's staged enabled/description
- add-port-ip: stage an IP (e.g. loopback /32) on a port interface; sends config.revision+1 and retries once on the 409 "found N" optimistic-lock mismatch

point-to-point-link (new resource):
- list/get/create/delete/config-example/add-ipv4-strategy
- create takes a full config-source body and can stage ipv4.subnetAllocationStrategies inline, so a link plus its manual /31 allocation strategy are created in a single call
- gated on network_fabrics_read/write