### PR TITLE
Fix YAML config parsing dropping camelCase keys

### DIFF
--- a/internal/route_domain/route_domain.go
+++ b/internal/route_domain/route_domain.go
@@ -108,6 +108,21 @@ func RouteDomainCreate(ctx context.Context, config []byte) error {
 		return err
 	}
 
+	// The API validates the three allocation-strategy fields as arrays and
+	// rejects the request ("... must be an array") when they are absent: a nil
+	// vrfAllocationStrategies slice serializes as null (it is a required field),
+	// and the nil l3V{lan,ni}AllocationStrategies slices are omitted entirely.
+	// Normalize nil slices to empty ones so they always marshal as [].
+	if routeDomainConfig.VrfAllocationStrategies == nil {
+		routeDomainConfig.VrfAllocationStrategies = []sdk.CreateVrfAllocationStrategy{}
+	}
+	if routeDomainConfig.L3VlanAllocationStrategies == nil {
+		routeDomainConfig.L3VlanAllocationStrategies = []sdk.CreateVlanAllocationStrategy{}
+	}
+	if routeDomainConfig.L3VniAllocationStrategies == nil {
+		routeDomainConfig.L3VniAllocationStrategies = []sdk.CreateVniAllocationStrategy{}
+	}
+
 	client := api.GetApiClient(ctx)
 
 	routeDomainInfo, httpRes, err := client.RouteDomainAPI.CreateRouteDomain(ctx).CreateRouteDomain(routeDomainConfig).Execute()

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -98,14 +98,14 @@ func UnmarshalContent(content []byte, destination any) error {
 			return fmt.Errorf("failed to unmarshal content: %w", err)
 		}
 	case "yaml":
-		err := yaml.Unmarshal(content, destination)
+		err := unmarshalYAML(content, destination)
 		if err != nil {
 			return fmt.Errorf("failed to unmarshal content: %w", err)
 		}
 	default:
 		err := json.Unmarshal(content, destination)
 		if err != nil {
-			err = yaml.Unmarshal(content, destination)
+			err = unmarshalYAML(content, destination)
 			if err != nil {
 				return fmt.Errorf("failed to unmarshal content: %w", err)
 			}
@@ -113,6 +113,28 @@ func UnmarshalContent(content []byte, destination any) error {
 	}
 
 	return nil
+}
+
+// unmarshalYAML decodes YAML by first converting it to JSON, then unmarshaling
+// that JSON into the destination. Destinations are typically SDK types that
+// carry only `json` tags (camelCase) plus custom UnmarshalJSON methods for
+// oneOf discrimination and required-property validation. yaml.Unmarshal ignores
+// both: it matches against lowercased Go field names, so camelCase keys (e.g.
+// vrfAllocationStrategies, resourceId) bind to nothing and are silently
+// dropped, and oneOf wrappers never populate. Routing through JSON makes YAML
+// input behave identically to JSON input.
+func unmarshalYAML(content []byte, destination any) error {
+	var intermediate interface{}
+	if err := yaml.Unmarshal(content, &intermediate); err != nil {
+		return err
+	}
+
+	jsonBytes, err := json.Marshal(intermediate)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(jsonBytes, destination)
 }
 
 func ProcessFilterStringSlice(filter []string) []string {


### PR DESCRIPTION
## Problem

`route-domain create` with a valid YAML config failed with:

```
400 Bad Request: ["l3VniAllocationStrategies must be an array", "l3VlanAllocationStrategies must be an array", "vrfAllocationStrategies must be an array"]
```

The emitted POST body was `{"kind":"evpn_l3vpn","label":"tenant15","name":"tenant15","vrfAllocationStrategies":null}` — the allocation strategies (and `autoRouteTarget`/`autoRouteDistinguisher`) had silently vanished.

## Root cause

The CLI treats YAML and JSON config as interchangeable, but SDK DTOs carry only `json:` tags (camelCase) plus custom `MarshalJSON`/`UnmarshalJSON` methods for `oneOf` discrimination, required-property validation, `omitempty`, and nullable handling. `yaml.Marshal`/`yaml.Unmarshal` ignore all of that and operate on *lowercased Go field names*, so:

- **Input:** camelCase YAML keys (`vrfAllocationStrategies`, `resourceId`, `granularityLevel`, ...) bound to nothing and were silently dropped.
- **Output:** `config-example -f yaml` emitted lowercase keys plus raw `oneOf` wrapper structs (`createManualVrfAllocationStrategy`), `AdditionalProperties`, and null variants — a template that could not be fed back into `create -f yaml`.

Latent across all ~40 YAML-configurable resources; masked because the broken input and broken output happened to agree with each other.

## Fix

- **`pkg/utils/utils.go`** — parse YAML by routing through JSON (`YAML → generic → json.Marshal → json.Unmarshal`), so YAML *input* behaves identically to JSON and invokes the SDK unmarshalers. Malformed configs now fail at parse with a clear SDK validation error instead of a confusing API 400.
- **`pkg/formatter/formatter.go`** — render YAML *output* via JSON (`value → json.Marshal → generic → yaml.Marshal`), so output is clean camelCase consistent with JSON and the parser. Fixes the `config-example → create` round-trip. Includes a regression test.
- **`internal/route_domain/route_domain.go`** — normalize nil allocation-strategy slices to `[]` on create so the API's array validation passes when a strategy list is omitted.

## Testing

- `go build ./...` and full `go test ./...` pass; BoringCrypto build succeeds.
- Local round-trip verified: `config-example -f yaml` output now parses back through `create -f yaml` (vrf=1, vni=1).
- Verified live against QA01 (camelCase input): the original "must be an array" error is gone; the API now parses and validates the full nested strategy payload. Remaining errors were about config *values* (VNI scope must be `global`), which are environment-specific, not CLI bugs.