### PR TITLE
Ms 9458

### DIFF
--- a/internal/job/cron_job.go
+++ b/internal/job/cron_job.go
@@ -2,7 +2,10 @@ package job
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"strconv"
 
 	"github.com/metalsoft-io/metalcloud-cli/pkg/api"
@@ -12,6 +15,15 @@ import (
 	"github.com/metalsoft-io/metalcloud-cli/pkg/utils"
 	sdk "github.com/metalsoft-io/metalcloud-sdk-go"
 )
+
+type cronJobRaw struct {
+	Id              interface{} `json:"id"`
+	Label           *string     `json:"label"`
+	FunctionName    *string     `json:"functionName"`
+	Schedule        *string     `json:"schedule"`
+	Disabled        interface{} `json:"disabled"`
+	LifetimeSeconds interface{} `json:"lifetimeSeconds"`
+}
 
 var cronJobPrintConfig = formatter.PrintConfig{
 	FieldsConfig: map[string]formatter.RecordFieldConfig{
@@ -32,6 +44,8 @@ var cronJobPrintConfig = formatter.PrintConfig{
 		"Disabled": {
 			Order: 5,
 			Transformer: func(v interface{}) string {
+				// The formatter normalizes whole numeric values to int64, so
+				// handle both float and integer representations.
 				switch val := v.(type) {
 				case float32:
 					if val == 0 {
@@ -39,6 +53,11 @@ var cronJobPrintConfig = formatter.PrintConfig{
 					}
 					return "disabled"
 				case float64:
+					if val == 0 {
+						return "enabled"
+					}
+					return "disabled"
+				case int64:
 					if val == 0 {
 						return "enabled"
 					}
@@ -61,12 +80,20 @@ func CronJobList(ctx context.Context) error {
 
 	request := client.JobAPI.GetCronJobs(ctx).SortBy([]string{"id:ASC"})
 
-	cronJobs, meta, err := utils.FetchAllPages(request)
+	rawItems, meta, err := utils.FetchAllPagesRaw(func(page float32) (*http.Response, error) {
+		_, httpRes, _ := request.Page(page).Limit(100).Execute()
+		return httpRes, nil
+	})
 	if err != nil {
 		return err
 	}
 
-	return utils.PrintAll(cronJobs, meta, len(cronJobs), &cronJobPrintConfig)
+	cronJobs, err := utils.UnmarshalRawItems[cronJobRaw](rawItems)
+	if err != nil {
+		return fmt.Errorf("failed to parse cron jobs: %w", err)
+	}
+
+	return utils.PrintAllRaw(rawItems, cronJobs, meta, len(cronJobs), &cronJobPrintConfig)
 }
 
 func CronJobGet(ctx context.Context, cronJobId string) error {
@@ -79,9 +106,23 @@ func CronJobGet(ctx context.Context, cronJobId string) error {
 
 	client := api.GetApiClient(ctx)
 
-	cronJob, httpRes, err := client.JobAPI.GetCronJob(ctx, id).Execute()
-	if err := response_inspector.InspectResponse(httpRes, err); err != nil {
-		return err
+	// Raw-body parse: see cronJobRaw — the `params` type mismatch breaks typed decoding.
+	_, httpRes, sdkErr := client.JobAPI.GetCronJob(ctx, id).Execute()
+	if httpRes != nil && httpRes.StatusCode >= 400 {
+		return response_inspector.InspectResponse(httpRes, sdkErr)
+	}
+	if httpRes == nil {
+		return sdkErr
+	}
+
+	body, err := io.ReadAll(httpRes.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var cronJob cronJobRaw
+	if err := json.Unmarshal(body, &cronJob); err != nil {
+		return fmt.Errorf("failed to parse cron job: %w", err)
 	}
 
 	return formatter.PrintResult(cronJob, &cronJobPrintConfig)

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -18,6 +18,14 @@ import (
 	"github.com/metalsoft-io/metalcloud-cli/pkg/utils"
 )
 
+type jobRaw struct {
+	JobId            interface{} `json:"jobId"`
+	Status           *string     `json:"status"`
+	FunctionName     *string     `json:"functionName"`
+	CreatedTimestamp *string     `json:"createdTimestamp"`
+	JobGroupId       interface{} `json:"jobGroupId"`
+}
+
 var jobPrintConfig = formatter.PrintConfig{
 	FieldsConfig: map[string]formatter.RecordFieldConfig{
 		"JobId": {
@@ -101,9 +109,24 @@ func JobGet(ctx context.Context, jobId string) error {
 
 	client := api.GetApiClient(ctx)
 
-	job, httpRes, err := client.JobAPI.GetJob(ctx, id).Execute()
-	if err := response_inspector.InspectResponse(httpRes, err); err != nil {
-		return err
+	// Raw-body parse: see jobRaw — the missing required `links` property breaks
+	// typed decoding.
+	_, httpRes, sdkErr := client.JobAPI.GetJob(ctx, id).Execute()
+	if httpRes != nil && httpRes.StatusCode >= 400 {
+		return response_inspector.InspectResponse(httpRes, sdkErr)
+	}
+	if httpRes == nil {
+		return sdkErr
+	}
+
+	body, err := io.ReadAll(httpRes.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var job jobRaw
+	if err := json.Unmarshal(body, &job); err != nil {
+		return fmt.Errorf("failed to parse job: %w", err)
 	}
 
 	return formatter.PrintResult(job, &jobPrintConfig)

--- a/internal/logical_network/logical_network.go
+++ b/internal/logical_network/logical_network.go
@@ -2,7 +2,10 @@ package logical_network
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"strconv"
 
 	"github.com/metalsoft-io/metalcloud-cli/internal/fabric"
@@ -13,6 +16,15 @@ import (
 	"github.com/metalsoft-io/metalcloud-cli/pkg/utils"
 	sdk "github.com/metalsoft-io/metalcloud-sdk-go"
 )
+
+type logicalNetworkRaw struct {
+	Id               interface{} `json:"id"`
+	Label            *string     `json:"label"`
+	Name             *string     `json:"name"`
+	Kind             *string     `json:"kind"`
+	FabricId         interface{} `json:"fabricId"`
+	InfrastructureId interface{} `json:"infrastructureId"`
+}
 
 var logicalNetworkPrintConfig = formatter.PrintConfig{
 	FieldsConfig: map[string]formatter.RecordFieldConfig{
@@ -95,25 +107,42 @@ func LogicalNetworkList(ctx context.Context, fabricIdOrLabel string, flags ListF
 		request = request.FilterFabricId([]string{fabric.Id})
 	}
 
+	printRaw := func(rawItems []json.RawMessage, meta sdk.PaginatedResponseMeta) error {
+		records, err := utils.UnmarshalRawItems[logicalNetworkRaw](rawItems)
+		if err != nil {
+			return fmt.Errorf("failed to parse logical networks: %w", err)
+		}
+		return utils.PrintAllRaw(rawItems, records, meta, len(records), &logicalNetworkPrintConfig)
+	}
+
 	switch {
 	case flags.Page > 0:
-		records, meta, err := utils.FetchPageWindow(request, flags.Page, flags.Limit)
+		rawItems, meta, err := utils.FetchPageWindowRaw(func(p, l float32) (*http.Response, error) {
+			_, httpRes, _ := request.Page(p).Limit(l).Execute()
+			return httpRes, nil
+		}, flags.Page, flags.Limit)
 		if err != nil {
 			return err
 		}
-		return utils.PrintAll(records, meta, len(records), &logicalNetworkPrintConfig)
+		return printRaw(rawItems, meta)
 	case flags.Limit > 0:
-		records, meta, err := utils.FetchUpTo(request, flags.Limit)
+		rawItems, meta, err := utils.FetchUpToRaw(func(p, l float32) (*http.Response, error) {
+			_, httpRes, _ := request.Page(p).Limit(l).Execute()
+			return httpRes, nil
+		}, flags.Limit)
 		if err != nil {
 			return err
 		}
-		return utils.PrintAll(records, meta, len(records), &logicalNetworkPrintConfig)
+		return printRaw(rawItems, meta)
 	default:
-		records, meta, err := utils.FetchAllPages(request)
+		rawItems, meta, err := utils.FetchAllPagesRaw(func(page float32) (*http.Response, error) {
+			_, httpRes, _ := request.Page(page).Limit(100).Execute()
+			return httpRes, nil
+		})
 		if err != nil {
 			return err
 		}
-		return utils.PrintAll(records, meta, len(records), &logicalNetworkPrintConfig)
+		return printRaw(rawItems, meta)
 	}
 }
 
@@ -127,9 +156,24 @@ func LogicalNetworkGet(ctx context.Context, logicalNetworkId string) error {
 
 	client := api.GetApiClient(ctx)
 
-	logicalNetwork, httpRes, err := client.LogicalNetworkAPI.GetLogicalNetwork(ctx, logicalNetworkIdNumeric).Execute()
-	if err := response_inspector.InspectResponse(httpRes, err); err != nil {
-		return err
+	// Raw-body parse: see logicalNetworkRaw — the nested allocation-strategy
+	// oneOf mismatch breaks typed decoding.
+	_, httpRes, sdkErr := client.LogicalNetworkAPI.GetLogicalNetwork(ctx, logicalNetworkIdNumeric).Execute()
+	if httpRes != nil && httpRes.StatusCode >= 400 {
+		return response_inspector.InspectResponse(httpRes, sdkErr)
+	}
+	if httpRes == nil {
+		return sdkErr
+	}
+
+	body, err := io.ReadAll(httpRes.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var logicalNetwork logicalNetworkRaw
+	if err := json.Unmarshal(body, &logicalNetwork); err != nil {
+		return fmt.Errorf("failed to parse logical network: %w", err)
 	}
 
 	return formatter.PrintResult(logicalNetwork, &logicalNetworkPrintConfig)

--- a/internal/server_default_credentials/server_default_credentials.go
+++ b/internal/server_default_credentials/server_default_credentials.go
@@ -3,6 +3,7 @@ package server_default_credentials
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strconv"
 
 	"github.com/metalsoft-io/metalcloud-cli/pkg/api"
@@ -13,6 +14,18 @@ import (
 
 	sdk "github.com/metalsoft-io/metalcloud-sdk-go"
 )
+type serverDefaultCredentialsRaw struct {
+	Id                           interface{} `json:"id"`
+	SiteId                       interface{} `json:"siteId"`
+	ServerSerialNumber           *string     `json:"serverSerialNumber"`
+	ServerMacAddress             *string     `json:"serverMacAddress"`
+	DefaultUsername              *string     `json:"defaultUsername"`
+	DefaultRackName              *string     `json:"defaultRackName"`
+	DefaultRackPositionLowerUnit *string     `json:"defaultRackPositionLowerUnit"`
+	DefaultRackPositionUpperUnit *string     `json:"defaultRackPositionUpperUnit"`
+	DefaultInventoryId           *string     `json:"defaultInventoryId"`
+	DefaultUuid                  *string     `json:"defaultUuid"`
+}
 
 var serverDefaultCredentialsPrintConfig = formatter.PrintConfig{
 	FieldsConfig: map[string]formatter.RecordFieldConfig{
@@ -68,27 +81,49 @@ func ServerDefaultCredentialsList(ctx context.Context, page int, limit int) erro
 	req := client.ServerDefaultCredentialsAPI.GetServersDefaultCredentials(ctx)
 
 	if page > 0 {
-		records, meta, err := utils.FetchPageWindow(req, page, limit)
+		rawItems, meta, err := utils.FetchPageWindowRaw(func(p, l float32) (*http.Response, error) {
+			_, httpRes, _ := req.Page(p).Limit(l).Execute()
+			return httpRes, nil
+		}, page, limit)
 		if err != nil {
 			return err
 		}
-		return utils.PrintAll(records, meta, len(records), &serverDefaultCredentialsPrintConfig)
+		records, err := utils.UnmarshalRawItems[serverDefaultCredentialsRaw](rawItems)
+		if err != nil {
+			return fmt.Errorf("failed to parse server default credentials: %w", err)
+		}
+		return utils.PrintAllRaw(rawItems, records, meta, len(records), &serverDefaultCredentialsPrintConfig)
 	}
 
 	if limit > 0 {
-		records, meta, err := utils.FetchUpTo(req, limit)
+		rawItems, meta, err := utils.FetchUpToRaw(func(p, l float32) (*http.Response, error) {
+			_, httpRes, _ := req.Page(p).Limit(l).Execute()
+			return httpRes, nil
+		}, limit)
 		if err != nil {
 			return err
 		}
-		return utils.PrintAll(records, meta, len(records), &serverDefaultCredentialsPrintConfig)
+		records, err := utils.UnmarshalRawItems[serverDefaultCredentialsRaw](rawItems)
+		if err != nil {
+			return fmt.Errorf("failed to parse server default credentials: %w", err)
+		}
+		return utils.PrintAllRaw(rawItems, records, meta, len(records), &serverDefaultCredentialsPrintConfig)
 	}
 
-	records, meta, err := utils.FetchAllPages(req)
+	rawItems, meta, err := utils.FetchAllPagesRaw(func(p float32) (*http.Response, error) {
+		_, httpRes, _ := req.Page(p).Limit(100).Execute()
+		return httpRes, nil
+	})
 	if err != nil {
 		return err
 	}
 
-	return utils.PrintAll(records, meta, len(records), &serverDefaultCredentialsPrintConfig)
+	records, err := utils.UnmarshalRawItems[serverDefaultCredentialsRaw](rawItems)
+	if err != nil {
+		return fmt.Errorf("failed to parse server default credentials: %w", err)
+	}
+
+	return utils.PrintAllRaw(rawItems, records, meta, len(records), &serverDefaultCredentialsPrintConfig)
 }
 
 func ServerDefaultCredentialsGet(ctx context.Context, credentialsId string) error {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -2,7 +2,10 @@ package storage
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"strconv"
 
 	"github.com/metalsoft-io/metalcloud-cli/pkg/api"
@@ -12,6 +15,16 @@ import (
 	"github.com/metalsoft-io/metalcloud-cli/pkg/utils"
 	sdk "github.com/metalsoft-io/metalcloud-sdk-go"
 )
+
+type storageRaw struct {
+	Id           interface{} `json:"id"`
+	SiteId       interface{} `json:"siteId"`
+	Driver       *string     `json:"driver"`
+	Technologies interface{} `json:"technologies"`
+	Type         *string     `json:"type"`
+	Name         *string     `json:"name"`
+	Status       *string     `json:"status"`
+}
 
 var StoragePrintConfig = formatter.PrintConfig{
 	FieldsConfig: map[string]formatter.RecordFieldConfig{
@@ -27,7 +40,7 @@ var StoragePrintConfig = formatter.PrintConfig{
 			Title: "Driver",
 			Order: 3,
 		},
-		"Technology": {
+		"Technologies": {
 			Title: "Technology",
 			Order: 4,
 		},
@@ -58,12 +71,20 @@ func StorageList(ctx context.Context, filterTechnology []string) error {
 	}
 	request = request.SortBy([]string{"id:ASC"})
 
-	records, meta, err := utils.FetchAllPages(request)
+	rawItems, meta, err := utils.FetchAllPagesRaw(func(page float32) (*http.Response, error) {
+		_, httpRes, _ := request.Page(page).Limit(100).Execute()
+		return httpRes, nil
+	})
 	if err != nil {
 		return err
 	}
 
-	return utils.PrintAll(records, meta, len(records), &StoragePrintConfig)
+	records, err := utils.UnmarshalRawItems[storageRaw](rawItems)
+	if err != nil {
+		return fmt.Errorf("failed to parse storages: %w", err)
+	}
+
+	return utils.PrintAllRaw(rawItems, records, meta, len(records), &StoragePrintConfig)
 }
 
 func StorageGet(ctx context.Context, storageId string) error {
@@ -76,9 +97,24 @@ func StorageGet(ctx context.Context, storageId string) error {
 
 	client := api.GetApiClient(ctx)
 
-	storage, httpRes, err := client.StorageAPI.GetStorage(ctx, storageIdNumeric).Execute()
-	if err := response_inspector.InspectResponse(httpRes, err); err != nil {
-		return err
+	// Raw-body parse: see storageRaw — the options.fibreChannel* type mismatch
+	// breaks typed decoding.
+	_, httpRes, sdkErr := client.StorageAPI.GetStorage(ctx, storageIdNumeric).Execute()
+	if httpRes != nil && httpRes.StatusCode >= 400 {
+		return response_inspector.InspectResponse(httpRes, sdkErr)
+	}
+	if httpRes == nil {
+		return sdkErr
+	}
+
+	body, err := io.ReadAll(httpRes.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var storage storageRaw
+	if err := json.Unmarshal(body, &storage); err != nil {
+		return fmt.Errorf("failed to parse storage: %w", err)
 	}
 
 	return formatter.PrintResult(storage, &StoragePrintConfig)


### PR DESCRIPTION
Fixed the following functions:

server-default-credentials list — failed with "cannot unmarshal string ... siteId"
storage list and storage get — failed with "cannot unmarshal number ... fibreChannelEnabled"
cron-job list and cron-job get — failed with a params type error
logical-network list and logical-network get — failed with "no value given for required property id"
job get — failed with "no value given for required property links"